### PR TITLE
Add Dimension type for Position structures

### DIFF
--- a/examples/src/main/java/team/catgirl/collar/examples/AuthorizationExample.java
+++ b/examples/src/main/java/team/catgirl/collar/examples/AuthorizationExample.java
@@ -1,6 +1,7 @@
 package team.catgirl.collar.examples;
 
 import com.google.common.io.Files;
+import team.catgirl.collar.api.location.Dimension;
 import team.catgirl.collar.api.location.Position;
 import team.catgirl.collar.client.Collar;
 import team.catgirl.collar.client.CollarConfiguration;
@@ -37,7 +38,7 @@ public class AuthorizationExample {
                 .withCollarServer("http://localhost:3000/")
                 .withHomeDirectory(new File("target"))
                 .withMojangAuthentication(() -> MinecraftSession.from(username, password, "smp.catgirl.team"))
-                .withPlayerPosition(() -> new Position(1d, 1d, 1d, 0))
+                .withPlayerPosition(() -> new Position(1d, 1d, 1d, Dimension.OVERWORLD))
                 .withListener(collarListener)
                 .build();
         Collar collar = Collar.create(configuration);

--- a/examples/src/main/java/team/catgirl/collar/examples/GroupsExample.java
+++ b/examples/src/main/java/team/catgirl/collar/examples/GroupsExample.java
@@ -1,6 +1,7 @@
 package team.catgirl.collar.examples;
 
 import team.catgirl.collar.api.groups.Group;
+import team.catgirl.collar.api.location.Dimension;
 import team.catgirl.collar.api.location.Position;
 import team.catgirl.collar.client.Collar;
 import team.catgirl.collar.client.CollarConfiguration;
@@ -83,7 +84,7 @@ public class GroupsExample {
                 .withCollarServer("http://localhost:3000/")
                 .withHomeDirectory(new File("target"))
                 .withMojangAuthentication(() -> MinecraftSession.from(username, password, "smp.catgirl.team"))
-                .withPlayerPosition(() -> new Position(1d, 1d, 1d, 0))
+                .withPlayerPosition(() -> new Position(1d, 1d, 1d, Dimension.OVERWORLD))
                 .withListener(collarListener)
                 .build();
 

--- a/shared/src/main/java/team/catgirl/collar/api/location/Dimension.java
+++ b/shared/src/main/java/team/catgirl/collar/api/location/Dimension.java
@@ -1,0 +1,11 @@
+package team.catgirl.collar.api.location;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
+public enum Dimension {
+    OVERWORLD,
+    NETHER,
+    END,
+    @JsonEnumDefaultValue
+    UNKNOWN
+}

--- a/shared/src/main/java/team/catgirl/collar/api/location/Position.java
+++ b/shared/src/main/java/team/catgirl/collar/api/location/Position.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public final class Position {
 
-    public static final Position UNKNOWN = new Position(-1d, -1d, -1d, -100);
+    public static final Position UNKNOWN = new Position(-1d, -1d, -1d, Dimension.UNKNOWN);
 
     @JsonProperty("x")
     public final Double x;
@@ -13,9 +13,9 @@ public final class Position {
     @JsonProperty("z")
     public final Double z;
     @JsonProperty("dimension")
-    public final Integer dimension;
+    public final Dimension dimension;
 
-    public Position(@JsonProperty("x") Double x, @JsonProperty("y") Double y, @JsonProperty("z") Double z, @JsonProperty("dimension") Integer dimension) {
+    public Position(@JsonProperty("x") Double x, @JsonProperty("y") Double y, @JsonProperty("z") Double z, @JsonProperty("dimension") Dimension dimension) {
         this.x = x;
         this.y = y;
         this.z = z;

--- a/shared/src/main/java/team/catgirl/collar/utils/Utils.java
+++ b/shared/src/main/java/team/catgirl/collar/utils/Utils.java
@@ -30,6 +30,7 @@ public final class Utils {
         });
 
         MAPPER = new ObjectMapper()
+                .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
                 .registerModules(keys);


### PR DESCRIPTION
Apparently the world/dimension IDs are different across different block game versions. So we have to have our own enum type. If collar cannot parse a new dimension type, it will default to `UNKNOWN`