### PR TITLE
Use MessagePack instead of JSON

### DIFF
--- a/client/src/main/java/team/catgirl/collar/client/Collar.java
+++ b/client/src/main/java/team/catgirl/collar/client/Collar.java
@@ -38,10 +38,8 @@ import team.catgirl.collar.protocol.trust.CheckTrustRelationshipResponse.IsUntru
 import team.catgirl.collar.security.ClientIdentity;
 import team.catgirl.collar.security.KeyPair.PublicKey;
 import team.catgirl.collar.security.ServerIdentity;
-import team.catgirl.collar.security.mojang.MinecraftSession;
 import team.catgirl.collar.utils.Utils;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.*;
@@ -164,7 +162,7 @@ public final class Collar {
         try (Response response = http.newCall(request).execute()) {
             if (response.code() == 200) {
                 byte[] bytes = Objects.requireNonNull(response.body()).bytes();
-                return Utils.createObjectMapper().readValue(bytes, aClass);
+                return Utils.jsonMapper().readValue(bytes, aClass);
             } else {
                 throw new ConnectionException("Failed to connect to server");
             }
@@ -174,7 +172,7 @@ public final class Collar {
     }
 
     class CollarWebSocket extends WebSocketListener {
-        private final ObjectMapper mapper = Utils.createObjectMapper();
+        private final ObjectMapper mapper = Utils.messagePackMapper();
         private final Collar collar;
         private KeepAlive keepAlive;
         private ServerIdentity serverIdentity;

--- a/client/src/main/java/team/catgirl/collar/client/security/ProfileState.java
+++ b/client/src/main/java/team/catgirl/collar/client/security/ProfileState.java
@@ -21,7 +21,7 @@ public final class ProfileState {
 
     public void write(HomeDirectory home) {
         try {
-            Utils.createObjectMapper().writeValue(new File(home.profile(), "profile.json"), this);
+            Utils.jsonMapper().writeValue(new File(home.profile(), "profile.json"), this);
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
@@ -29,7 +29,7 @@ public final class ProfileState {
 
     public static ProfileState read(HomeDirectory home)  {
         try {
-            return Utils.createObjectMapper().readValue(new File(home.profile(), "profile.json"), ProfileState.class);
+            return Utils.jsonMapper().readValue(new File(home.profile(), "profile.json"), ProfileState.class);
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }

--- a/client/src/main/java/team/catgirl/collar/client/security/signal/ClientPreKeyStore.java
+++ b/client/src/main/java/team/catgirl/collar/client/security/signal/ClientPreKeyStore.java
@@ -97,7 +97,7 @@ public final class ClientPreKeyStore implements PreKeyStore {
         File file = new File(home.security(), "clientPreKeyStore.json");
         State state;
         if (file.exists()) {
-            state = Utils.createObjectMapper().readValue(file, State.class);
+            state = Utils.jsonMapper().readValue(file, State.class);
         } else {
             state = new State(new HashMap<>());
         }

--- a/client/src/main/java/team/catgirl/collar/client/security/signal/ClientSessionStore.java
+++ b/client/src/main/java/team/catgirl/collar/client/security/signal/ClientSessionStore.java
@@ -172,7 +172,7 @@ public class ClientSessionStore implements SessionStore {
         File file = new File(homeDirectory.security(), "clientSessionStore.json");
         State state;
         if (file.exists()) {
-            state = Utils.createObjectMapper().readValue(file, State.class);
+            state = Utils.jsonMapper().readValue(file, State.class);
         } else {
             state = new State(new HashMap<>());
         }

--- a/client/src/main/java/team/catgirl/collar/client/security/signal/ClientSignalProtocolStore.java
+++ b/client/src/main/java/team/catgirl/collar/client/security/signal/ClientSignalProtocolStore.java
@@ -153,7 +153,7 @@ public class ClientSignalProtocolStore implements SignalProtocolStore {
                 gen.writeFieldName(value.name + ":" + value.deviceId);
             }
         });
-        ObjectMapper mapper = Utils.createObjectMapper().registerModule(simpleModule);
+        ObjectMapper mapper = Utils.jsonMapper().registerModule(simpleModule);
         return new ClientSignalProtocolStore(
                 ClientIdentityKeyStore.from(home, mapper),
                 ClientPreKeyStore.from(home, mapper),

--- a/client/src/main/java/team/catgirl/collar/client/security/signal/ClientSignedPreKeyStore.java
+++ b/client/src/main/java/team/catgirl/collar/client/security/signal/ClientSignedPreKeyStore.java
@@ -117,7 +117,7 @@ public class ClientSignedPreKeyStore implements SignedPreKeyStore {
         File file = new File(home.security(), "signedPreKeyStore.json");
         State state;
         if (file.exists()) {
-            state = Utils.createObjectMapper().readValue(file, State.class);
+            state = Utils.jsonMapper().readValue(file, State.class);
         } else {
             state = new State(new HashMap<>());
         }

--- a/client/src/main/java/team/catgirl/collar/client/security/signal/SignalClientIdentityStore.java
+++ b/client/src/main/java/team/catgirl/collar/client/security/signal/SignalClientIdentityStore.java
@@ -197,7 +197,7 @@ public final class SignalClientIdentityStore implements ClientIdentityStore {
         SignalClientIdentityStore clientIdentityStore;
         if (file.exists()) {
             try {
-                state = Utils.createObjectMapper().readValue(file, State.class);
+                state = Utils.jsonMapper().readValue(file, State.class);
             } catch (IOException e) {
                 throw new IllegalStateException("Could not read profile store", e);
             }
@@ -231,6 +231,6 @@ public final class SignalClientIdentityStore implements ClientIdentityStore {
     }
 
     private static void writeState(File file, State state) throws IOException {
-        Utils.createObjectMapper().writeValue(file, state);
+        Utils.jsonMapper().writeValue(file, state);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson-databind.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.msgpack</groupId>
+                <artifactId>jackson-dataformat-msgpack</artifactId>
+                <version>0.7.1</version>
+            </dependency>
             <!-- likewise I am not using some brain dead http library -->
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>

--- a/server/src/main/java/team/catgirl/collar/server/session/SessionManager.java
+++ b/server/src/main/java/team/catgirl/collar/server/session/SessionManager.java
@@ -47,11 +47,11 @@ public final class SessionManager {
             .expireAfterWrite(10, TimeUnit.MINUTES)
             .build();
 
-    private final ObjectMapper mapper;
+    private final ObjectMapper protobuf;
     private final ServerIdentityStore store;
 
     public SessionManager(ObjectMapper mapper, ServerIdentityStore store) {
-        this.mapper = mapper;
+        this.protobuf = mapper;
         this.store = store;
     }
 
@@ -107,7 +107,7 @@ public final class SessionManager {
     }
 
     public void send(Session session, ClientIdentity recipient, ProtocolResponse resp) throws IOException {
-        PacketIO packetIO = new PacketIO(mapper, store.createCypher());
+        PacketIO packetIO = new PacketIO(protobuf, store.createCypher());
         ByteBuffer buffer;
         if (isIdentified(session)) {
             buffer = ByteBuffer.wrap(packetIO.encodeEncrypted(recipient, resp));

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -21,6 +21,10 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.msgpack</groupId>
+            <artifactId>jackson-dataformat-msgpack</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/shared/src/main/java/team/catgirl/collar/protocol/ProtocolRequest.java
+++ b/shared/src/main/java/team/catgirl/collar/protocol/ProtocolRequest.java
@@ -2,9 +2,10 @@ package team.catgirl.collar.protocol;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import team.catgirl.collar.security.ClientIdentity;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "t")
 public abstract class ProtocolRequest {
     @JsonProperty("identity")
     public final ClientIdentity identity;

--- a/shared/src/main/java/team/catgirl/collar/protocol/ProtocolResponse.java
+++ b/shared/src/main/java/team/catgirl/collar/protocol/ProtocolResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import team.catgirl.collar.security.ServerIdentity;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "t")
 public abstract class ProtocolResponse {
     @JsonProperty("identity")
     public final ServerIdentity identity;

--- a/shared/src/main/java/team/catgirl/collar/security/TokenGenerator.java
+++ b/shared/src/main/java/team/catgirl/collar/security/TokenGenerator.java
@@ -6,7 +6,7 @@ import team.catgirl.collar.utils.Utils;
 import java.security.SecureRandom;
 
 public final class TokenGenerator {
-    private static final SecureRandom RANDOM = Utils.createSecureRandom();
+    private static final SecureRandom RANDOM = Utils.secureRandom();
 
     public static String verificationCode() {
         StringBuilder buffer = new StringBuilder();

--- a/shared/src/main/java/team/catgirl/collar/security/signal/PreKeys.java
+++ b/shared/src/main/java/team/catgirl/collar/security/signal/PreKeys.java
@@ -19,9 +19,9 @@ public final class PreKeys {
 
     public static PreKeyBundle generate(SignalProtocolAddress address, SignalProtocolStore store) {
         ECKeyPair signedPreKey = Curve.generateKeyPair();
-        int signedPreKeyId = Utils.createSecureRandom().nextInt(Medium.MAX_VALUE);
+        int signedPreKeyId = Utils.secureRandom().nextInt(Medium.MAX_VALUE);
         ECKeyPair unsignedPreKey = Curve.generateKeyPair();
-        int unsignedPreKeyId = Utils.createSecureRandom().nextInt(Medium.MAX_VALUE);
+        int unsignedPreKeyId = Utils.secureRandom().nextInt(Medium.MAX_VALUE);
         byte[] signature;
         try {
             signature = Curve.calculateSignature(store.getIdentityKeyPair().getPrivateKey(), signedPreKey.getPublicKey().serialize());
@@ -94,7 +94,7 @@ public final class PreKeys {
         List<PreKeyRecord> preKeys = KeyHelper.generatePreKeys(1, 500);
         SignedPreKeyRecord signedPreKey;
         try {
-            signedPreKey = KeyHelper.generateSignedPreKey(identityKeyPair, Utils.createSecureRandom().nextInt(Medium.MAX_VALUE));
+            signedPreKey = KeyHelper.generateSignedPreKey(identityKeyPair, Utils.secureRandom().nextInt(Medium.MAX_VALUE));
         } catch (InvalidKeyException e) {
             throw new IllegalStateException("problem generating signed preKey", e);
         }

--- a/shared/src/main/java/team/catgirl/collar/utils/Utils.java
+++ b/shared/src/main/java/team/catgirl/collar/utils/Utils.java
@@ -3,6 +3,7 @@ package team.catgirl.collar.utils;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.msgpack.jackson.dataformat.MessagePackFactory;
 import team.catgirl.collar.security.mojang.MinecraftPlayer;
 
 import java.io.IOException;
@@ -11,6 +12,9 @@ import java.security.SecureRandom;
 import java.util.UUID;
 
 public final class Utils {
+
+    private static final ObjectMapper JSON_MAPPER;
+    private static final ObjectMapper MESSAGE_PACK_MAPPER;
 
     static {
         SimpleModule keys = new SimpleModule();
@@ -29,14 +33,18 @@ public final class Utils {
             }
         });
 
-        MAPPER = new ObjectMapper()
+        JSON_MAPPER = new ObjectMapper()
+                .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+                .registerModules(keys);
+
+        MESSAGE_PACK_MAPPER = new ObjectMapper(new MessagePackFactory())
                 .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
                 .registerModules(keys);
     }
-
-    private static final ObjectMapper MAPPER;
 
     public static final SecureRandom SECURERANDOM;
 
@@ -48,11 +56,15 @@ public final class Utils {
         }
     }
 
-    public static ObjectMapper createObjectMapper() {
-        return MAPPER;
+    public static ObjectMapper jsonMapper() {
+        return JSON_MAPPER;
     }
 
-    public static SecureRandom createSecureRandom() {
+    public static ObjectMapper messagePackMapper() {
+        return MESSAGE_PACK_MAPPER;
+    }
+
+    public static SecureRandom secureRandom() {
         return SECURERANDOM;
     }
 


### PR DESCRIPTION
Uses the faster and more efficient [MessagePack](https://msgpack.org/index.html) format for packets.

Basically the same performance as Protobuffs except we don't have to write schemas or deal with horrible autogenerated API for package messages. In some cases its [more space efficient and faster than protobuf](https://medium.com/@hugovs/the-need-for-speed-experimenting-with-message-serialization-93d7562b16e4).

@0-x-2-2 @original I think this is a decent middle ground. Thoughts?