### PR TITLE
Simple Distributed Hashtable

### DIFF
--- a/shared/src/main/java/team/catgirl/collar/sdht/Content.java
+++ b/shared/src/main/java/team/catgirl/collar/sdht/Content.java
@@ -1,0 +1,80 @@
+package team.catgirl.collar.sdht;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.hash.Hashing;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+public final class Content {
+
+    private static final int MAX_SIZE = 2000;
+
+    @JsonProperty("checksum")
+    public final byte[] checksum;
+    @JsonProperty("bytes")
+    public final byte[] bytes;
+    @JsonProperty("author")
+    public final UUID author;
+
+    private Content(@JsonProperty("checksum") byte[] checksum,
+                    @JsonProperty("bytes") byte[] bytes,
+                    @JsonProperty("author") UUID author) {
+        this.checksum = checksum;
+        this.bytes = bytes;
+        this.author = author;
+    }
+
+    /**
+     * Checks that the content within is valid
+     * @return validity
+     */
+    public boolean isValid() {
+        if (bytes.length > MAX_SIZE) {
+            return false;
+        }
+        byte[] checksum = createChecksum(bytes);
+        return Arrays.equals(this.checksum, checksum);
+    }
+
+    /**
+     * Checks that the record checksum and the content checksum match
+     * @param record to test
+     * @return validity
+     */
+    public boolean isValid(Record record) {
+        byte[] checksum = createChecksum(bytes);
+        return Arrays.equals(record.checksum, checksum);
+    }
+
+    /**
+     * Create a record based on the key and its content
+     * @param key addressing the content
+     * @return record
+     */
+    public Record toRecord(Key key) {
+        return new Record(key, checksum);
+    }
+
+    /**
+     * Create content from bytes
+     * @param bytes to store
+     * @param author of the content
+     * @return content
+     */
+    public static Content from(byte[] bytes, UUID author) {
+        assertSize(bytes);
+        byte[] checksum = createChecksum(bytes);
+        return new Content(checksum, bytes, author);
+    }
+
+    private static byte[] createChecksum(byte[] bytes) {
+        return Hashing.sha256().hashBytes(bytes).asBytes();
+    }
+
+    private static void assertSize(byte[] bytes) {
+        if (bytes.length > MAX_SIZE) {
+            throw new IllegalStateException("content size exceeds " + MAX_SIZE + " bytes");
+        }
+    }
+}

--- a/shared/src/main/java/team/catgirl/collar/sdht/Content.java
+++ b/shared/src/main/java/team/catgirl/collar/sdht/Content.java
@@ -10,10 +10,21 @@ public final class Content {
 
     private static final int MAX_SIZE = 2000;
 
+    /**
+     * Checksum of content
+     */
     @JsonProperty("checksum")
     public final byte[] checksum;
+
+    /**
+     * Content
+     */
     @JsonProperty("bytes")
     public final byte[] bytes;
+
+    /**
+     * For debugging purposes. Not to be relied on.
+     */
     @JsonProperty("author")
     public final UUID author;
 
@@ -76,5 +87,20 @@ public final class Content {
         if (bytes.length > MAX_SIZE) {
             throw new IllegalStateException("content size exceeds " + MAX_SIZE + " bytes");
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Content content = (Content) o;
+        return Arrays.equals(checksum, content.checksum) && Arrays.equals(bytes, content.bytes);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(checksum);
+        result = 31 * result + Arrays.hashCode(bytes);
+        return result;
     }
 }

--- a/shared/src/main/java/team/catgirl/collar/sdht/DistributedHashTable.java
+++ b/shared/src/main/java/team/catgirl/collar/sdht/DistributedHashTable.java
@@ -1,42 +1,29 @@
 package team.catgirl.collar.sdht;
 
-import com.google.common.collect.ImmutableSet;
-
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicReference;
 
-public final class DistributedHashTable {
+public interface DistributedHashTable {
+    /**
+     * Return all of the records in the DHT
+     * @return records
+     */
+    Set<Record> records();
 
-    private static final int MAX_RECORDS = Short.MAX_VALUE;
-
-    private final ConcurrentMap<UUID, ConcurrentMap<UUID, Content>> namespacedData = new ConcurrentHashMap<>();
-
-    public Set<Record> records() {
-        ImmutableSet.Builder<Record> records = ImmutableSet.builder();
-        namespacedData.forEach((namespaceId, contentMap) -> {
-            contentMap.forEach((id, content) -> records.add(new Record(new Key(namespaceId, id), content.checksum)));
-        });
-        return records.build();
-    }
+    /**
+     * Return all of the records in the DHT belonging to the provided namespace
+     * @param namespace to use
+     * @return records
+     */
+    Set<Record> records(UUID namespace);
 
     /**
      * Get the content for the provided record
      * @param record to get
      * @return content or if the record was not valid, empty
      */
-    public Optional<Content> get(Record record) {
-        ConcurrentMap<UUID, Content> contentMap = namespacedData.get(record.key.namespace);
-        if (contentMap == null) {
-            return Optional.empty();
-        }
-        Content content = contentMap.get(record.key.id);
-        return content == null || !content.isValid(record) ? Optional.empty() : Optional.of(content);
-    }
+    Optional<Content> get(Record record);
 
     /**
      * Add the content to the hash table
@@ -44,38 +31,12 @@ public final class DistributedHashTable {
      * @param content to add
      * @return content added
      */
-    public Optional<Content> putIfAbsent(Record record, Content content) {
-        if (!content.isValid(record) || !content.isValid()) {
-            return Optional.empty();
-        }
-        AtomicReference<Content> computedContent = new AtomicReference<>();
-        namespacedData.compute(record.key.namespace, (namespace, contentMap) -> {
-            contentMap = contentMap == null ? new ConcurrentHashMap<>() : contentMap;
-            Content computed = contentMap.computeIfAbsent(record.key.id, contentId -> content);
-            computedContent.set(computed);
-            return contentMap;
-        });
-        return computedContent.get() == null ? Optional.empty() : Optional.of(computedContent.get());
-    }
+    Optional<Content> putIfAbsent(Record record, Content content);
 
     /**
      * Remove the content at key
      * @param record addressing the content
      * @return content removed
      */
-    public Optional<Content> remove(Record record) {
-        AtomicReference<Content> removedContent = new AtomicReference<>();
-        namespacedData.compute(record.key.namespace, (namespaceId, contentMap) -> {
-            if (contentMap == null) {
-                return null;
-            }
-            Content content = contentMap.get(record.key.id);
-            if (content != null && content.isValid(record)) {
-                Content removed = contentMap.remove(record.key.id);
-                removedContent.set(removed);
-            }
-            return contentMap.isEmpty() ? null : contentMap;
-        });
-        return removedContent.get() == null ? Optional.empty() : Optional.of(removedContent.get());
-    }
+    Optional<Content> remove(Record record);
 }

--- a/shared/src/main/java/team/catgirl/collar/sdht/DistributedHashTable.java
+++ b/shared/src/main/java/team/catgirl/collar/sdht/DistributedHashTable.java
@@ -1,0 +1,81 @@
+package team.catgirl.collar.sdht;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class DistributedHashTable {
+
+    private static final int MAX_RECORDS = Short.MAX_VALUE;
+
+    private final ConcurrentMap<UUID, ConcurrentMap<UUID, Content>> namespacedData = new ConcurrentHashMap<>();
+
+    public Set<Record> records() {
+        ImmutableSet.Builder<Record> records = ImmutableSet.builder();
+        namespacedData.forEach((namespaceId, contentMap) -> {
+            contentMap.forEach((id, content) -> records.add(new Record(new Key(namespaceId, id), content.checksum)));
+        });
+        return records.build();
+    }
+
+    /**
+     * Get the content for the provided record
+     * @param record to get
+     * @return content or if the record was not valid, empty
+     */
+    public Optional<Content> get(Record record) {
+        ConcurrentMap<UUID, Content> contentMap = namespacedData.get(record.key.namespace);
+        if (contentMap == null) {
+            return Optional.empty();
+        }
+        Content content = contentMap.get(record.key.id);
+        return content == null || !content.isValid(record) ? Optional.empty() : Optional.of(content);
+    }
+
+    /**
+     * Add the content to the hash table
+     * @param record to add
+     * @param content to add
+     * @return content added
+     */
+    public Optional<Content> putIfAbsent(Record record, Content content) {
+        if (!content.isValid(record) || !content.isValid()) {
+            return Optional.empty();
+        }
+        AtomicReference<Content> computedContent = new AtomicReference<>();
+        namespacedData.compute(record.key.namespace, (namespace, contentMap) -> {
+            contentMap = contentMap == null ? new ConcurrentHashMap<>() : contentMap;
+            Content computed = contentMap.computeIfAbsent(record.key.id, contentId -> content);
+            computedContent.set(computed);
+            return contentMap;
+        });
+        return computedContent.get() == null ? Optional.empty() : Optional.of(computedContent.get());
+    }
+
+    /**
+     * Remove the content at key
+     * @param record addressing the content
+     * @return content removed
+     */
+    public Optional<Content> remove(Record record) {
+        AtomicReference<Content> removedContent = new AtomicReference<>();
+        namespacedData.compute(record.key.namespace, (namespaceId, contentMap) -> {
+            if (contentMap == null) {
+                return null;
+            }
+            Content content = contentMap.get(record.key.id);
+            if (content != null && content.isValid(record)) {
+                Content removed = contentMap.remove(record.key.id);
+                removedContent.set(removed);
+            }
+            return contentMap.isEmpty() ? null : contentMap;
+        });
+        return removedContent.get() == null ? Optional.empty() : Optional.of(removedContent.get());
+    }
+}

--- a/shared/src/main/java/team/catgirl/collar/sdht/InMemoryDistributedHashTable.java
+++ b/shared/src/main/java/team/catgirl/collar/sdht/InMemoryDistributedHashTable.java
@@ -59,8 +59,10 @@ public final class InMemoryDistributedHashTable implements DistributedHashTable 
             if (contentMap.size() > MAX_RECORDS) {
                 throw new IllegalStateException("namespace " + namespace + " exceeded maximum records " + MAX_RECORDS);
             }
-            Content computed = contentMap.computeIfAbsent(record.key.id, contentId -> content);
-            computedContent.set(computed);
+            if (!contentMap.containsKey(record.key.id)) {
+                computedContent.set(content);
+            }
+            contentMap.computeIfAbsent(record.key.id, contentId -> content);
             return contentMap;
         });
         return computedContent.get() == null ? Optional.empty() : Optional.of(computedContent.get());

--- a/shared/src/main/java/team/catgirl/collar/sdht/InMemoryDistributedHashTable.java
+++ b/shared/src/main/java/team/catgirl/collar/sdht/InMemoryDistributedHashTable.java
@@ -1,0 +1,85 @@
+package team.catgirl.collar.sdht;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class InMemoryDistributedHashTable implements DistributedHashTable {
+
+    private static final int MAX_RECORDS = Short.MAX_VALUE;
+
+    private final ConcurrentMap<UUID, ConcurrentMap<UUID, Content>> namespacedData = new ConcurrentHashMap<>();
+
+    @Override
+    public Set<Record> records() {
+        ImmutableSet.Builder<Record> records = ImmutableSet.builder();
+        namespacedData.forEach((namespaceId, contentMap) -> {
+            contentMap.forEach((id, content) -> records.add(new Record(new Key(namespaceId, id), content.checksum)));
+        });
+        return records.build();
+    }
+
+    @Override
+    public Set<Record> records(UUID namespace) {
+        ConcurrentMap<UUID, Content> contentMap = namespacedData.get(namespace);
+        if (contentMap == null) {
+            return ImmutableSet.of();
+        }
+        ImmutableSet.Builder<Record> records = ImmutableSet.builder();
+        contentMap.forEach((id, content) -> records.add(new Record(new Key(namespace, id), content.checksum)));
+        return records.build();
+    }
+
+    @Override
+    public Optional<Content> get(Record record) {
+        ConcurrentMap<UUID, Content> contentMap = namespacedData.get(record.key.namespace);
+        if (contentMap == null) {
+            return Optional.empty();
+        }
+        Content content = contentMap.get(record.key.id);
+        return content == null || !content.isValid(record) ? Optional.empty() : Optional.of(content);
+    }
+
+    @Override
+    public Optional<Content> putIfAbsent(Record record, Content content) {
+        if (!content.isValid(record) || !content.isValid()) {
+            return Optional.empty();
+        }
+        if (namespacedData.size() > MAX_RECORDS) {
+            throw new IllegalStateException("Maximum namespaces exceeds " + MAX_RECORDS);
+        }
+        AtomicReference<Content> computedContent = new AtomicReference<>();
+        namespacedData.compute(record.key.namespace, (namespace, contentMap) -> {
+            contentMap = contentMap == null ? new ConcurrentHashMap<>() : contentMap;
+            if (contentMap.size() > MAX_RECORDS) {
+                throw new IllegalStateException("namespace " + namespace + " exceeded maximum records " + MAX_RECORDS);
+            }
+            Content computed = contentMap.computeIfAbsent(record.key.id, contentId -> content);
+            computedContent.set(computed);
+            return contentMap;
+        });
+        return computedContent.get() == null ? Optional.empty() : Optional.of(computedContent.get());
+    }
+
+    @Override
+    public Optional<Content> remove(Record record) {
+        AtomicReference<Content> removedContent = new AtomicReference<>();
+        namespacedData.compute(record.key.namespace, (namespaceId, contentMap) -> {
+            if (contentMap == null) {
+                return null;
+            }
+            Content content = contentMap.get(record.key.id);
+            if (content != null && content.isValid(record)) {
+                Content removed = contentMap.remove(record.key.id);
+                removedContent.set(removed);
+            }
+            return contentMap.isEmpty() ? null : contentMap;
+        });
+        return removedContent.get() == null ? Optional.empty() : Optional.of(removedContent.get());
+    }
+}

--- a/shared/src/main/java/team/catgirl/collar/sdht/Key.java
+++ b/shared/src/main/java/team/catgirl/collar/sdht/Key.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * Key for {@link Content} within the {@link DistributedHashTable}
+ * Key for {@link Content} within the {@link InMemoryDistributedHashTable}
  */
 public final class Key {
     @JsonProperty("ns")

--- a/shared/src/main/java/team/catgirl/collar/sdht/Key.java
+++ b/shared/src/main/java/team/catgirl/collar/sdht/Key.java
@@ -1,0 +1,35 @@
+package team.catgirl.collar.sdht;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Key for {@link Content} within the {@link DistributedHashTable}
+ */
+public final class Key {
+    @JsonProperty("ns")
+    public final UUID namespace;
+    @JsonProperty("id")
+    public final UUID id;
+
+    public Key(@JsonProperty("ns") UUID namespace,
+               @JsonProperty("id") UUID id) {
+        this.namespace = namespace;
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Key key = (Key) o;
+        return namespace.equals(key.namespace) && id.equals(key.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(namespace, id);
+    }
+}

--- a/shared/src/main/java/team/catgirl/collar/sdht/Record.java
+++ b/shared/src/main/java/team/catgirl/collar/sdht/Record.java
@@ -1,0 +1,37 @@
+package team.catgirl.collar.sdht;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * SDHT record used to referring to content across nodes
+ */
+public final class Record {
+    @JsonProperty("key")
+    public final Key key;
+    @JsonProperty("checksum")
+    public final byte[] checksum;
+
+    public Record(@JsonProperty("key") Key key,
+                  @JsonProperty("checksum") byte[] checksum) {
+        this.key = key;
+        this.checksum = checksum;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Record record = (Record) o;
+        return key.equals(record.key) && Arrays.equals(checksum, record.checksum);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(key);
+        result = 31 * result + Arrays.hashCode(checksum);
+        return result;
+    }
+}

--- a/shared/src/test/java/team/catgirl/collar/sdht/DistributedHashTableTest.java
+++ b/shared/src/test/java/team/catgirl/collar/sdht/DistributedHashTableTest.java
@@ -1,0 +1,48 @@
+package team.catgirl.collar.sdht;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import team.catgirl.collar.security.TokenGenerator;
+
+import java.util.Set;
+import java.util.UUID;
+
+public class DistributedHashTableTest {
+    private DistributedHashTable table;
+
+    @Before
+    public void setup() {
+        table = new InMemoryDistributedHashTable();
+    }
+
+    @Test
+    public void hashTableOperations() {
+        UUID namespace = UUID.randomUUID();
+        byte[] bytes = TokenGenerator.byteToken(256);
+        UUID author = UUID.randomUUID();
+        Content content = Content.from(bytes, author);
+        UUID contentId = UUID.randomUUID();
+        Record record = content.toRecord(new Key(namespace, contentId));
+
+        Assert.assertTrue("content self validates", content.isValid());
+        Assert.assertTrue("content validates against record", content.isValid(record));
+
+        Content addedContent = table.putIfAbsent(record, content).orElse(null);
+        Assert.assertEquals("content can be added", addedContent, content);
+
+        Assert.assertFalse("Can put into hash table again", table.putIfAbsent(record, content).isPresent());
+        Assert.assertTrue("Record exists", table.get(record).isPresent());
+
+        Assert.assertEquals("has record", ImmutableSet.of(record), table.records());
+        Assert.assertEquals("has record in namespace", ImmutableSet.of(record), table.records(namespace));
+        Assert.assertEquals("does not have a record in random namespace", ImmutableSet.of(), table.records(UUID.randomUUID()));
+
+        Content removedContent = table.remove(record).orElse(null);
+        Assert.assertEquals("Content can be removed", removedContent, content);
+        Assert.assertFalse("content was removed", table.remove(record).isPresent());
+        Assert.assertEquals("no records in hash table", ImmutableSet.of(), table.records());
+        Assert.assertEquals("no records in namespace", ImmutableSet.of(), table.records(namespace));
+    }
+}


### PR DESCRIPTION
Used for sharing content with groups of users like so:

```
DistributedHashTable hashTable = new InMemoryDistributedHashTable();
Content content = Content.from(bytes, profileIdOfAuthor);
Record record = content.toRecord(new Key(groupId, contentId));
hashTable.putIfAbsent(record, content).ifPresent(content -> distributeToNodes(record))
```

This PR does not yet contain the networking or tests. Will be making use of SDHT in #64 for distributing group waypoint data and will include a generalised networking layer to distribute the state across nodes including tests.

@aGreenLizard as we discussed. 