### PR TITLE
Private identity token management

### DIFF
--- a/client/src/main/java/team/catgirl/collar/client/Collar.java
+++ b/client/src/main/java/team/catgirl/collar/client/Collar.java
@@ -421,6 +421,7 @@ public final class Collar {
                     configuration.listener.onMinecraftAccountVerificationFailed(collar, response.minecraftSession);
                 } else if (resp instanceof PrivateIdentityMismatchResponse) {
                     PrivateIdentityMismatchResponse response = (PrivateIdentityMismatchResponse) resp;
+                    LOGGER.log(Level.INFO, "SessionFailedResponse with private identity mismatch");
                     configuration.listener.onPrivateIdentityMismatch(collar, response.url);
                 } else {
                     LOGGER.log(Level.INFO, "SessionFailedResponse with general server failure");

--- a/client/src/main/java/team/catgirl/collar/client/Collar.java
+++ b/client/src/main/java/team/catgirl/collar/client/Collar.java
@@ -352,7 +352,8 @@ public final class Collar {
                 LOGGER.log(Level.INFO, "Existing installation. Loading the store and identifying with server " + serverIdentity);
                 IdentityKey publicKey = store.getIdentityKeyPair().getPublicKey();
                 ClientIdentity clientIdentity = new ClientIdentity(finalOwner, new PublicKey(publicKey.serialize()), null);
-                IdentifyRequest request = new IdentifyRequest(clientIdentity);
+                PrivateIdentity privateIdentity = PrivateIdentity.getOrCreate(configuration.homeDirectory);
+                IdentifyRequest request = new IdentifyRequest(clientIdentity, privateIdentity.token);
                 sendRequest(webSocket, request);
             }));
         }
@@ -385,7 +386,7 @@ public final class Collar {
                 if (identityStore == null) {
                     identityStore = getOrCreateIdentityKeyStore(webSocket, response.profile.id);
                 }
-                StartSessionRequest request = new StartSessionRequest(identity, configuration.sessionSupplier.get(), identityStore.privateIdentityToken());
+                StartSessionRequest request = new StartSessionRequest(identity, configuration.sessionSupplier.get());
                 sendRequest(webSocket, request);
                 keepAlive.stop();
                 keepAlive.start(identity);
@@ -409,7 +410,7 @@ public final class Collar {
                 }
                 identityStore.trustIdentity(response.identity, response.preKeyBundle);
                 LOGGER.log(Level.INFO, "PreKeys have been exchanged successfully");
-                sendRequest(webSocket, new IdentifyRequest(identity));
+                sendRequest(webSocket, new IdentifyRequest(identity, identityStore.privateIdentityToken()));
             } else if (resp instanceof StartSessionResponse) {
                 LOGGER.log(Level.INFO, "Session has started. Checking if the client and server are in a trusted relationship");
                 sendRequest(webSocket, new CheckTrustRelationshipRequest(identity));

--- a/client/src/main/java/team/catgirl/collar/client/CollarListener.java
+++ b/client/src/main/java/team/catgirl/collar/client/CollarListener.java
@@ -1,5 +1,6 @@
 package team.catgirl.collar.client;
 
+import team.catgirl.collar.client.Collar.State;
 import team.catgirl.collar.client.security.ClientIdentityStore;
 import team.catgirl.collar.security.mojang.MinecraftSession;
 
@@ -17,7 +18,7 @@ public interface CollarListener {
      * @param collar client
      * @param state of the client connection
      */
-    default void onStateChanged(Collar collar, Collar.State state) {}
+    default void onStateChanged(Collar collar, State state) {}
 
     /**
      * Fired when the server or client cannot negotiate trust with the client
@@ -33,4 +34,13 @@ public interface CollarListener {
      * @param session of minecraft client
      */
     default void onMinecraftAccountVerificationFailed(Collar collar, MinecraftSession session) {};
+
+    /**
+     * Fired when the server detects a mismatch between the stored private identity and the one provided by the session
+     * User will have to visit a page on the collar web app to confirm that they want to delete encrypted blobs stored
+     * against their user or provide the identity file and start again
+     * @param collar client
+     * @param url to visit
+     */
+    default void onPrivateIdentityMismatch(Collar collar, String url) {};
 }

--- a/server/src/main/java/team/catgirl/collar/server/CollarServer.java
+++ b/server/src/main/java/team/catgirl/collar/server/CollarServer.java
@@ -151,7 +151,7 @@ public class CollarServer {
 
     private boolean processPrivateIdentityToken(Profile profile, IdentifyRequest req) {
         if (profile.privateIdentityToken == null || profile.privateIdentityToken.length == 0) {
-            services.profiles.updateProfile(RequestContext.SERVER, UpdateProfileRequest.privateIdentityToken(req.privateIdentityToken));
+            services.profiles.updateProfile(RequestContext.SERVER, UpdateProfileRequest.privateIdentityToken(profile.id, req.privateIdentityToken));
             return true;
         }
         return Arrays.equals(profile.privateIdentityToken, req.privateIdentityToken);

--- a/server/src/main/java/team/catgirl/collar/server/WebServer.java
+++ b/server/src/main/java/team/catgirl/collar/server/WebServer.java
@@ -5,6 +5,7 @@ import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
 import team.catgirl.collar.api.http.*;
+import team.catgirl.collar.api.http.HttpException.BadRequestException;
 import team.catgirl.collar.api.http.HttpException.ForbiddenException;
 import team.catgirl.collar.api.http.HttpException.ServerErrorException;
 import team.catgirl.collar.api.http.HttpException.UnauthorisedException;
@@ -22,7 +23,9 @@ import team.catgirl.collar.server.services.authentication.VerificationToken;
 import team.catgirl.collar.server.services.devices.DeviceService;
 import team.catgirl.collar.server.services.devices.DeviceService.TrustDeviceResponse;
 import team.catgirl.collar.server.services.profiles.Profile;
+import team.catgirl.collar.server.services.profiles.ProfileService;
 import team.catgirl.collar.server.services.profiles.ProfileService.GetProfileRequest;
+import team.catgirl.collar.server.services.profiles.ProfileService.UpdateProfileRequest;
 import team.catgirl.collar.server.services.textures.TextureService.GetTextureContentRequest;
 import team.catgirl.collar.utils.Utils;
 
@@ -133,6 +136,17 @@ public class WebServer {
                         String id = request.params("id");
                         UUID uuid = UUID.fromString(id);
                         return services.profiles.getProfile(RequestContext.SERVER, GetProfileRequest.byId(uuid)).profile.toPublic();
+                    });
+                    post("/reset", (request, response) -> {
+                        LoginRequest req = services.jsonMapper.readValue(request.bodyAsBytes(), LoginRequest.class);
+                        RequestContext context = RequestContext.from(request);
+                        LoginResponse loginResp = services.auth.login(context, req);
+                        if (!loginResp.profile.id.equals(context.owner)) {
+                            throw new BadRequestException("user mismatch");
+                        }
+                        services.profileStorage.delete(context.owner);
+                        services.profiles.updateProfile(context, UpdateProfileRequest.privateIdentityToken(new byte[0]));
+                        return new Object();
                     });
                     get("/devices", (request, response) -> {
                         return services.devices.findDevices(RequestContext.from(request), services.jsonMapper.readValue(request.bodyAsBytes(), DeviceService.FindDevicesRequest.class));

--- a/server/src/main/java/team/catgirl/collar/server/WebServer.java
+++ b/server/src/main/java/team/catgirl/collar/server/WebServer.java
@@ -145,7 +145,7 @@ public class WebServer {
                             throw new BadRequestException("user mismatch");
                         }
                         services.profileStorage.delete(context.owner);
-                        services.profiles.updateProfile(context, UpdateProfileRequest.privateIdentityToken(new byte[0]));
+                        services.profiles.updateProfile(context, UpdateProfileRequest.privateIdentityToken(loginResp.profile.id, new byte[0]));
                         return new Object();
                     });
                     get("/devices", (request, response) -> {

--- a/server/src/main/java/team/catgirl/collar/server/http/AppUrlProvider.java
+++ b/server/src/main/java/team/catgirl/collar/server/http/AppUrlProvider.java
@@ -24,6 +24,12 @@ public interface AppUrlProvider {
     String signupUrl();
 
     /**
+     * URL to reset the private identity token and delete encrypted blobs
+     * @return url
+     */
+    String resetPrivateIdentity();
+
+    /**
      * URL for verifying the device
      * @param token to link identity and device
      * @return url
@@ -36,5 +42,9 @@ public interface AppUrlProvider {
      */
     String emailVerificationUrl(String token);
 
+    /**
+     * @param token of password reset
+     * @return url
+     */
     String resetPassword(String token);
 }

--- a/server/src/main/java/team/catgirl/collar/server/http/CollarWebAppUrlProvider.java
+++ b/server/src/main/java/team/catgirl/collar/server/http/CollarWebAppUrlProvider.java
@@ -41,6 +41,11 @@ public class CollarWebAppUrlProvider implements AppUrlProvider {
     }
 
     @Override
+    public String resetPrivateIdentity() {
+        return builder.withPath("/reset").toString();
+    }
+
+    @Override
     public String deviceVerificationUrl(String token) {
         return builder.withPath("/device/accept/" + token).toString();
     }

--- a/server/src/main/java/team/catgirl/collar/server/http/DefaultAppUrlProvider.java
+++ b/server/src/main/java/team/catgirl/collar/server/http/DefaultAppUrlProvider.java
@@ -25,6 +25,11 @@ public class DefaultAppUrlProvider implements AppUrlProvider {
     }
 
     @Override
+    public String resetPrivateIdentity() {
+        return this.baseUrl.withPath("/app/reset/").toString();
+    }
+
+    @Override
     public String deviceVerificationUrl(String token) {
         return this.baseUrl.withPath("/app/devices/trust/" + token).toString();
     }

--- a/server/src/main/java/team/catgirl/collar/server/services/profiles/Profile.java
+++ b/server/src/main/java/team/catgirl/collar/server/services/profiles/Profile.java
@@ -18,21 +18,28 @@ public final class Profile {
     public final String hashedPassword;
     @JsonProperty("emailVerified")
     public final Boolean emailVerified;
+    @JsonProperty("privateIdentityToken")
+    public final byte[] privateIdentityToken;
 
-    public Profile(UUID id, String email, String name, String hashedPassword, Boolean emailVerified) {
+    public Profile(UUID id, String email, String name, String hashedPassword, Boolean emailVerified, byte[] privateIdentityToken) {
         this.id = id;
         this.email = email;
         this.name = name;
         this.hashedPassword = hashedPassword;
         this.emailVerified = emailVerified;
+        this.privateIdentityToken = privateIdentityToken;
     }
 
     @JsonCreator
-    public Profile(@JsonProperty("id") UUID id, @JsonProperty("email") String email, @JsonProperty("name") String name, @JsonProperty("name") Boolean emailVerified) {
+    public Profile(@JsonProperty("id") UUID id,
+                   @JsonProperty("email") String email,
+                   @JsonProperty("name") String name,
+                   @JsonProperty("name") Boolean emailVerified) {
         this.id = id;
         this.email = email;
         this.name = name;
         this.emailVerified = emailVerified;
+        this.privateIdentityToken = null;
         this.hashedPassword = null;
     }
 

--- a/server/src/main/java/team/catgirl/collar/server/services/profiles/ProfileService.java
+++ b/server/src/main/java/team/catgirl/collar/server/services/profiles/ProfileService.java
@@ -114,11 +114,11 @@ public class ProfileService {
             throw new BadRequestException("bad request");
         }
         if (result.wasAcknowledged()) {
-            Document document = docs.find(eq("_id", result.getUpsertedId().asObjectId().getValue())).first();
-            if (document == null) {
+            Document first = docs.find(eq(FIELD_PROFILE_ID, req.profile)).first();
+            if (first == null) {
                 throw new NotFoundException("could not find profile");
             }
-            return new UpdateProfileResponse(map(document));
+            return new UpdateProfileResponse(map(first));
         } else {
             throw new ServerErrorException("could not update profile");
         }
@@ -208,8 +208,8 @@ public class ProfileService {
             return new UpdateProfileRequest(profile, null, newPassword, null);
         }
 
-        public static UpdateProfileRequest privateIdentityToken(byte[] privateIdentityToken) {
-            return new UpdateProfileRequest(null, null, null, privateIdentityToken);
+        public static UpdateProfileRequest privateIdentityToken(UUID profile, byte[] privateIdentityToken) {
+            return new UpdateProfileRequest(profile, null, null, privateIdentityToken);
         }
     }
 

--- a/server/src/main/java/team/catgirl/collar/server/services/profiles/ProfileService.java
+++ b/server/src/main/java/team/catgirl/collar/server/services/profiles/ProfileService.java
@@ -9,6 +9,7 @@ import com.mongodb.client.result.UpdateResult;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.bson.BsonObjectId;
 import org.bson.Document;
+import org.bson.types.Binary;
 import team.catgirl.collar.api.http.HttpException.BadRequestException;
 import team.catgirl.collar.api.http.HttpException.ConflictException;
 import team.catgirl.collar.api.http.HttpException.NotFoundException;
@@ -31,6 +32,7 @@ public class ProfileService {
     private static final String FIELD_NAME = "name";
     private static final String FIELD_HASHED_PASSWORD = "hashedPassword";
     private static final String FIELD_EMAIL_VERIFIED = "emailVerified";
+    private static final String FIELD_PRIVATE_IDENTITY_TOKEN = "privateIdentityToken";
 
     private final MongoCollection<Document> docs;
     private final PasswordHashing passwordHashing;
@@ -106,6 +108,8 @@ public class ProfileService {
             result = docs.updateOne(eq(FIELD_PROFILE_ID, req.profile), new Document("$set", new Document(FIELD_EMAIL_VERIFIED, req.emailVerified)));
         } else if (req.hashedPassword != null) {
             result = docs.updateOne(eq(FIELD_PROFILE_ID, req.profile), new Document("$set", new Document(FIELD_HASHED_PASSWORD, req.hashedPassword)));
+        } else if (req.privateIdentityToken != null) {
+            result = docs.updateOne(eq(FIELD_PROFILE_ID, req.profile), new Document("$set", new Document(FIELD_PRIVATE_IDENTITY_TOKEN, req.privateIdentityToken)));
         } else {
             throw new BadRequestException("bad request");
         }
@@ -172,7 +176,8 @@ public class ProfileService {
         String name = doc.getString(FIELD_NAME);
         String hashedPassword = doc.getString(FIELD_HASHED_PASSWORD);
         boolean emailVerified = doc.getBoolean(FIELD_EMAIL_VERIFIED, false);
-        return new Profile(profileId, email, name, hashedPassword, emailVerified);
+        Binary privateIdentityToken = doc.get(FIELD_PRIVATE_IDENTITY_TOKEN, Binary.class);
+        return new Profile(profileId, email, name, hashedPassword, emailVerified, privateIdentityToken != null ? privateIdentityToken.getData() : null);
     }
 
     public static final class UpdateProfileRequest {
@@ -182,29 +187,29 @@ public class ProfileService {
         public final Boolean emailVerified;
         @JsonProperty("hashedPassword")
         public final String hashedPassword;
+        @JsonProperty("privateIdentityToken")
+        public final byte[] privateIdentityToken;
 
         public UpdateProfileRequest(@JsonProperty("profile") UUID profile,
                                     @JsonProperty("emailVerified") Boolean emailVerified,
-                                    @JsonProperty("hashedPassword") String hashedPassword) {
+                                    @JsonProperty("hashedPassword") String hashedPassword,
+                                    @JsonProperty("privateIdentityToken") byte[] privateIdentityToken) {
             this.profile = profile;
             this.emailVerified = emailVerified;
             this.hashedPassword = hashedPassword;
+            this.privateIdentityToken = privateIdentityToken;
         }
 
         public static UpdateProfileRequest emailVerified(UUID profile) {
-            return new UpdateProfileRequest(profile, true, null);
+            return new UpdateProfileRequest(profile, true, null, null);
         }
 
         public static UpdateProfileRequest hashedPassword(UUID profile, String newPassword) {
-            return new UpdateProfileRequest(profile, null, newPassword);
+            return new UpdateProfileRequest(profile, null, newPassword, null);
         }
 
-        public static UpdateProfileRequest removeWaypoint(UUID waypointId) {
-            return null;
-        }
-
-        public static UpdateProfileRequest addWaypoint(UUID waypointId, byte[] waypoint) {
-            return null;
+        public static UpdateProfileRequest privateIdentityToken(byte[] privateIdentityToken) {
+            return new UpdateProfileRequest(null, null, null, privateIdentityToken);
         }
     }
 

--- a/server/src/main/java/team/catgirl/collar/server/services/profiles/ProfileService.java
+++ b/server/src/main/java/team/catgirl/collar/server/services/profiles/ProfileService.java
@@ -109,16 +109,16 @@ public class ProfileService {
         } else if (req.hashedPassword != null) {
             result = docs.updateOne(eq(FIELD_PROFILE_ID, req.profile), new Document("$set", new Document(FIELD_HASHED_PASSWORD, req.hashedPassword)));
         } else if (req.privateIdentityToken != null) {
-            result = docs.updateOne(eq(FIELD_PROFILE_ID, req.profile), new Document("$set", new Document(FIELD_PRIVATE_IDENTITY_TOKEN, req.privateIdentityToken)));
+            result = docs.updateOne(eq(FIELD_PROFILE_ID, req.profile), new Document("$set", new Document(FIELD_PRIVATE_IDENTITY_TOKEN, new Binary(req.privateIdentityToken))));
         } else {
             throw new BadRequestException("bad request");
         }
         if (result.wasAcknowledged()) {
-            Document first = docs.find(eq(FIELD_PROFILE_ID, req.profile)).first();
-            if (first == null) {
+            Document document = docs.find(eq("_id", result.getUpsertedId().asObjectId().getValue())).first();
+            if (document == null) {
                 throw new NotFoundException("could not find profile");
             }
-            return new UpdateProfileResponse(map(first));
+            return new UpdateProfileResponse(map(document));
         } else {
             throw new ServerErrorException("could not update profile");
         }

--- a/server/src/main/java/team/catgirl/collar/server/services/profiles/storage/ProfileStorage.java
+++ b/server/src/main/java/team/catgirl/collar/server/services/profiles/storage/ProfileStorage.java
@@ -31,6 +31,13 @@ public class ProfileStorage {
         this.docs.createIndex(new Document(index));
     }
 
+    /**
+     * Store a {@link Blob} belonging to a profile by its key and type
+     * @param owner of the blob
+     * @param key of the blob
+     * @param data representing the contents of the blob
+     * @param type of the blob
+     */
     public void store(UUID owner, UUID key, byte[] data, String type) {
         Map<String, Object> state = Map.of(FIELD_OWNER, owner, FIELD_KEY, key, FIELD_DATA, new Binary(data), FIELD_TYPE, type);
         UpdateResult result = docs.updateOne(and(eq(FIELD_OWNER, owner), eq(FIELD_KEY, key)), new Document("$set", new Document(state)), new UpdateOptions().upsert(true));
@@ -39,10 +46,26 @@ public class ProfileStorage {
         }
     }
 
+    /**
+     * Delete a blob belonging to the owner with a specific key
+     * @param owner of the blob
+     * @param key to delete
+     */
     public void delete(UUID owner, UUID key) {
         DeleteResult result = docs.deleteOne(and(eq(FIELD_OWNER, owner), eq(FIELD_KEY, key)));
         if (!result.wasAcknowledged()) {
             throw new IllegalStateException("could not delete data for owner " + owner + " key " + key);
+        }
+    }
+
+    /**
+     * Delete all the blobs beloning to the owner
+     * @param owner to remove all blobs
+     */
+    public void delete(UUID owner) {
+        DeleteResult result = docs.deleteMany(eq(FIELD_OWNER, owner));
+        if (!result.wasAcknowledged()) {
+            throw new IllegalStateException("could not delete data for owner " + owner);
         }
     }
 

--- a/shared/src/main/java/team/catgirl/collar/protocol/identity/IdentifyRequest.java
+++ b/shared/src/main/java/team/catgirl/collar/protocol/identity/IdentifyRequest.java
@@ -9,15 +9,20 @@ import team.catgirl.collar.security.ClientIdentity;
  * When sent with a null identity, prompts a login response
  */
 public final class IdentifyRequest extends ProtocolRequest {
+    @JsonProperty("privateIdentityToken")
+    public final byte[] privateIdentityToken;
+
     @JsonCreator
-    public IdentifyRequest(@JsonProperty("identity") ClientIdentity identity) {
+    public IdentifyRequest(@JsonProperty("identity") ClientIdentity identity,
+                           @JsonProperty("privateIdentityToken") byte[] privateIdentityToken) {
         super(identity);
+        this.privateIdentityToken = privateIdentityToken;
     }
 
     /**
      * @return identify request that will prompt the client to negotiate an identity with collar
      */
     public static IdentifyRequest unknown() {
-        return new IdentifyRequest(null);
+        return new IdentifyRequest(null, null);
     }
 }

--- a/shared/src/main/java/team/catgirl/collar/protocol/identity/IdentifyResponse.java
+++ b/shared/src/main/java/team/catgirl/collar/protocol/identity/IdentifyResponse.java
@@ -11,7 +11,8 @@ public final class IdentifyResponse extends ProtocolResponse {
     public final PublicProfile profile;
 
     @JsonCreator
-    public IdentifyResponse(@JsonProperty("identity") ServerIdentity identity, @JsonProperty("profile") PublicProfile profile) {
+    public IdentifyResponse(@JsonProperty("identity") ServerIdentity identity,
+                            @JsonProperty("profile") PublicProfile profile) {
         super(identity);
         this.profile = profile;
     }

--- a/shared/src/main/java/team/catgirl/collar/protocol/session/SessionFailedResponse.java
+++ b/shared/src/main/java/team/catgirl/collar/protocol/session/SessionFailedResponse.java
@@ -22,9 +22,27 @@ public abstract class SessionFailedResponse extends ProtocolResponse {
         public final MinecraftSession minecraftSession;
 
         @JsonCreator
-        public MojangVerificationFailedResponse(@JsonProperty("identity") ServerIdentity identity, @JsonProperty("minecraftSession") MinecraftSession minecraftSession) {
+        public MojangVerificationFailedResponse(@JsonProperty("identity") ServerIdentity identity,
+                                                @JsonProperty("minecraftSession") MinecraftSession minecraftSession) {
             super(identity);
             this.minecraftSession = minecraftSession;
+        }
+    }
+
+    /**
+     * Fired when there is a mismatch between the stored private identity token and the token supplied by the client
+     * on the {@link StartSessionRequest}
+     * The user will need to login to collar and delete their data before proceeding
+     */
+    public static final class PrivateIdentityMismatchResponse extends SessionFailedResponse {
+        @JsonProperty("url")
+        public final String url;
+
+        @JsonCreator
+        public PrivateIdentityMismatchResponse(@JsonProperty("identity") ServerIdentity identity,
+                                               @JsonProperty("url") String url) {
+            super(identity);
+            this.url = url;
         }
     }
 

--- a/shared/src/main/java/team/catgirl/collar/protocol/session/StartSessionRequest.java
+++ b/shared/src/main/java/team/catgirl/collar/protocol/session/StartSessionRequest.java
@@ -9,15 +9,11 @@ import team.catgirl.collar.security.mojang.MinecraftSession;
 public final class StartSessionRequest extends ProtocolRequest {
     @JsonProperty("session")
     public final MinecraftSession session;
-    @JsonProperty("privateIdentityToken")
-    public final byte[] privateIdentityToken;
 
     @JsonCreator
     public StartSessionRequest(@JsonProperty("identity") ClientIdentity identity,
-                               @JsonProperty("session") MinecraftSession session,
-                               @JsonProperty("privateIdentityToken") byte[] privateIdentityToken) {
+                               @JsonProperty("session") MinecraftSession session) {
         super(identity);
         this.session = session;
-        this.privateIdentityToken = privateIdentityToken;
     }
 }

--- a/shared/src/main/java/team/catgirl/collar/protocol/session/StartSessionRequest.java
+++ b/shared/src/main/java/team/catgirl/collar/protocol/session/StartSessionRequest.java
@@ -15,7 +15,7 @@ public final class StartSessionRequest extends ProtocolRequest {
     @JsonCreator
     public StartSessionRequest(@JsonProperty("identity") ClientIdentity identity,
                                @JsonProperty("session") MinecraftSession session,
-                               @JsonProperty("session") byte[] privateIdentityToken) {
+                               @JsonProperty("privateIdentityToken") byte[] privateIdentityToken) {
         super(identity);
         this.session = session;
         this.privateIdentityToken = privateIdentityToken;

--- a/shared/src/main/java/team/catgirl/collar/protocol/session/StartSessionRequest.java
+++ b/shared/src/main/java/team/catgirl/collar/protocol/session/StartSessionRequest.java
@@ -9,10 +9,15 @@ import team.catgirl.collar.security.mojang.MinecraftSession;
 public final class StartSessionRequest extends ProtocolRequest {
     @JsonProperty("session")
     public final MinecraftSession session;
+    @JsonProperty("privateIdentityToken")
+    public final byte[] privateIdentityToken;
 
     @JsonCreator
-    public StartSessionRequest(@JsonProperty("identity") ClientIdentity identity, @JsonProperty("session") MinecraftSession session) {
+    public StartSessionRequest(@JsonProperty("identity") ClientIdentity identity,
+                               @JsonProperty("session") MinecraftSession session,
+                               @JsonProperty("session") byte[] privateIdentityToken) {
         super(identity);
         this.session = session;
+        this.privateIdentityToken = privateIdentityToken;
     }
 }

--- a/shared/src/main/java/team/catgirl/collar/utils/IO.java
+++ b/shared/src/main/java/team/catgirl/collar/utils/IO.java
@@ -1,6 +1,7 @@
 package team.catgirl.collar.utils;
 
 import java.io.*;
+import java.nio.file.Files;
 
 public final class IO {
     /**
@@ -29,6 +30,32 @@ public final class IO {
             bytes[i] = is.readByte();
         }
         return bytes;
+    }
+
+    /**
+     * Write all bytes to file
+     * @param file to write to
+     * @param bytes to write
+     */
+    public static void writeBytesToFile(File file, byte[] bytes) {
+        try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+            fileOutputStream.write(bytes);
+        } catch (IOException e) {
+            throw new IllegalStateException("could not write bytes to file " + file);
+        }
+    }
+
+    /**
+     * Read all the bytes from a file
+     * @param file to read from
+     * @return bytes
+     */
+    public static byte[] readBytesFromFile(File file) {
+        try {
+            return Files.readAllBytes(file.toPath());
+        } catch (IOException e) {
+            throw new IllegalStateException("could not read all bytes from file " + file);
+        }
     }
 
     public IO() {}


### PR DESCRIPTION
Final component of #61

When we encrypt private data for storage on the server that belongs to the profile (e.g. a private waypoint) we generate a AES secret key that the client uses to encrypt/decrypt blobs it sends or retrieves from the server.

If a player logs into a second computer, they won't have the secret key and cannot decrypt their blobs.

In this scenario, the user needs to be prompted to copy their secret key from the first computer to the second and reconnect. In the event that they have lost this key, they can visit a special URL on the web app and clear the encrypted blobs (they would lose their waypoints). 

This PR handles how this occurs when the session is started. There is a new method on the collar listener for the client to present the reset URL. @original you will need to update your `CollarListener` and implement `onPrivateIdentityMismatch`. It should work just like `onConfirmDeviceRegistration`.

@joerez we will need to add this URL to collar web. The user must confirm the reset action by providing their email and password and have the web app post `LoginRequest` to `/api/1/profile/reset`.

This page should also have an explanation of what resetting means, instructions on how to find the `identity.cif` file containing their secret key on the first computer and place it on the second computer. 

Once this is done, the client can reconnect and everything works fine. 